### PR TITLE
fix: keep-aliveワークフローのSupabase環境変数名をプロジェクト規約に統一

### DIFF
--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -13,11 +13,12 @@ jobs:
     steps:
       - name: Ping Supabase
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          # プロジェクト共通の命名 (NEXT_PUBLIC_*) を優先し、旧名をフォールバックとして許容
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.SUPABASE_ANON_KEY }}
         run: |
           if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ]; then
-            echo "⚠️ SUPABASE_URL または SUPABASE_ANON_KEY が設定されていません"
+            echo "⚠️ NEXT_PUBLIC_SUPABASE_URL または NEXT_PUBLIC_SUPABASE_ANON_KEY が設定されていません"
             echo "GitHubリポジトリの Settings > Secrets and variables > Actions で設定してください"
             exit 1
           fi


### PR DESCRIPTION
ワークフローが旧名 SUPABASE_URL / SUPABASE_ANON_KEY のみを参照しており、
プロジェクト全体で使用している NEXT_PUBLIC_SUPABASE_* と不一致だったため
シークレット未検出で失敗していた。NEXT_PUBLIC_* を優先しつつ旧名を
フォールバックとして許容するよう修正。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * サービスの稼働監視ワークフローを更新。新旧の環境変数命名規約の両方に対応し、後方互換性を確保しました。システムの信頼性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->