### PR TITLE
feat: 新規 TODO を末尾ではなく先頭に追加する

### DIFF
--- a/__tests__/bulk-todo-order.test.tsx
+++ b/__tests__/bulk-todo-order.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { BulkTodoDialog } from "@/components/calendar/bulk-todo-dialog";
+import { CALENDAR_TEXT } from "@/lib/constants";
+import type { CalendarEvent } from "@/types/calendar";
+
+const mockLinkTodo = jest.fn();
+
+jest.mock("@/hooks/useTodoEventLinks", () => ({
+  useTodoEventLinks: () => ({
+    linkTodo: (...args: unknown[]) => mockLinkTodo(...args),
+    error: null,
+  }),
+}));
+
+function event(eventId: string, summary: string, startAt: string): CalendarEvent {
+  return {
+    eventKey: eventId,
+    eventId,
+    calendarId: "cal-1",
+    summary,
+    startAt,
+    endAt: startAt,
+    isAllDay: false,
+    status: "confirmed",
+    linkedTodoIds: [],
+  };
+}
+
+// 時系列の3件。ダイアログ内では早い順に並ぶ
+const EVENTS = [
+  event("evt-mon", "月曜の朝会", "2026-07-27T00:00:00.000Z"),
+  event("evt-wed", "水曜のレビュー", "2026-07-29T00:00:00.000Z"),
+  event("evt-fri", "金曜の締め会", "2026-07-31T00:00:00.000Z"),
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLinkTodo.mockResolvedValue(true);
+});
+
+/**
+ * addTodo は「先頭に積む」実装なので、呼び出し順が時系列の昇順だと
+ * 画面上は降順に並んでしまう。ダイアログ側が逆順で呼ぶことで
+ * 積み上げた結果が時系列の昇順になる、という関係を検証する。
+ */
+it("一括 TODO 化は、積み上げた結果が時系列順になるよう逆順で作成する", async () => {
+  const created: string[] = [];
+  const onAddTodo = jest.fn(async (text: string) => {
+    created.push(text);
+    return `todo-${created.length}`;
+  });
+
+  const user = userEvent.setup();
+  render(
+    <BulkTodoDialog
+      open
+      events={EVENTS}
+      periodLabel="今週"
+      onAddTodo={onAddTodo}
+      onClose={jest.fn()}
+      onCompleted={jest.fn()}
+    />
+  );
+
+  await user.click(screen.getByText("月曜の朝会"));
+  await user.click(screen.getByText("水曜のレビュー"));
+  await user.click(screen.getByText("金曜の締め会"));
+
+  await user.click(screen.getByRole("button", { name: CALENDAR_TEXT.bulkTodoSubmit }));
+
+  await waitFor(() => expect(onAddTodo).toHaveBeenCalledTimes(3));
+
+  // 作成は遅い予定から。先頭に積まれるので最終的な並びは 月→水→金 になる
+  expect(created).toEqual(["金曜の締め会", "水曜のレビュー", "月曜の朝会"]);
+
+  // 先頭挿入を模して積み直すと、時系列の昇順に戻ることを明示する
+  const displayed = created.reduce<string[]>((list, text) => [text, ...list], []);
+  expect(displayed).toEqual(["月曜の朝会", "水曜のレビュー", "金曜の締め会"]);
+});

--- a/__tests__/supabase-integration.test.tsx
+++ b/__tests__/supabase-integration.test.tsx
@@ -260,6 +260,9 @@ describe('Supabase Integration Tests', () => {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
         order: jest.fn().mockReturnThis(),
+        // 先頭挿入では既存の最小 order_index を引く。既存 0 件なら order_index は 0
+        limit: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
       });
 
       const TestComponent = () => {

--- a/__tests__/todo-order.test.tsx
+++ b/__tests__/todo-order.test.tsx
@@ -1,0 +1,261 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { User } from "@supabase/supabase-js";
+import { useTodoManager } from "@/hooks/useTodoManager";
+import { useSupabaseTodos } from "@/hooks/useSupabaseTodos";
+
+// Supabase クライアントは 1 リクエストずつ組み立てを検証したいので、
+// テーブル単位で呼び出しを記録できる薄いモックに差し替える
+const mockFrom = jest.fn();
+
+// リアルタイム購読のコールバックを掴んでおき、他端末からの INSERT を再現する
+type RealtimeHandler = (payload: {
+  eventType: string;
+  new?: Record<string, unknown>;
+  old?: Record<string, unknown>;
+}) => void;
+let realtimeHandler: RealtimeHandler | null = null;
+
+jest.mock("@/lib/supabase", () => ({
+  isSupabaseConfigured: true,
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    channel: () => {
+      const ch = {
+        on: (_event: string, _filter: unknown, handler: RealtimeHandler) => {
+          realtimeHandler = handler;
+          return ch;
+        },
+        subscribe: () => ch,
+      };
+      return ch;
+    },
+    removeChannel: jest.fn(),
+    auth: {
+      onAuthStateChange: jest.fn(() => ({
+        data: { subscription: { unsubscribe: jest.fn() } },
+      })),
+    },
+  },
+}));
+
+const USER = { id: "user-1" } as User;
+
+type DbTodo = {
+  id: string;
+  text: string;
+  is_completed: boolean;
+  order_index: number;
+};
+
+/**
+ * todos テーブルのクエリビルダー模造品。
+ * - select().eq().order().limit().maybeSingle() … 最小 order_index の取得
+ * - select().eq().order()                        … 一覧取得
+ * - insert().select().single()                   … 追加
+ * 全メソッドが自分自身を返しつつ thenable なので、どの終端でも await できる。
+ */
+function createTodosMock(existing: DbTodo[]) {
+  const inserted: Record<string, unknown>[] = [];
+  let insertedRow: Record<string, unknown> | null = null;
+
+  const ascending = [...existing].sort((a, b) => a.order_index - b.order_index);
+
+  const builder: Record<string, unknown> = {};
+  let limited = false;
+
+  const resolve = () => {
+    if (insertedRow) return { data: insertedRow, error: null };
+    if (limited) return { data: ascending[0] ?? null, error: null };
+    return { data: ascending, error: null };
+  };
+
+  for (const method of ["select", "eq", "order", "single", "maybeSingle"]) {
+    builder[method] = () => builder;
+  }
+  builder.limit = () => {
+    limited = true;
+    return builder;
+  };
+  builder.insert = (row: Record<string, unknown>) => {
+    inserted.push(row);
+    insertedRow = { id: "new-todo-id", ...row };
+    return builder;
+  };
+  builder.then = (
+    onfulfilled?: (value: ReturnType<typeof resolve>) => unknown,
+    onrejected?: (reason: unknown) => unknown
+  ) => Promise.resolve(resolve()).then(onfulfilled, onrejected);
+
+  return { builder, inserted };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  realtimeHandler = null;
+});
+
+describe("新規 TODO は先頭に追加される（ローカル保存時）", () => {
+  const renderManager = () =>
+    renderHook(() =>
+      useTodoManager({ useDatabase: false, user: null, setAlarmPoints: jest.fn() })
+    );
+
+  it("2 件追加すると、後から追加した方が先頭に来る", async () => {
+    const { result } = renderManager();
+
+    await act(async () => {
+      await result.current.addTodo("古いタスク");
+    });
+    await act(async () => {
+      await result.current.addTodo("新しいタスク");
+    });
+
+    expect(result.current.sharedTodos.map((t) => t.text)).toEqual([
+      "新しいタスク",
+      "古いタスク",
+    ]);
+  });
+
+  it("既存の並び順は崩さず、先頭にだけ差し込む", async () => {
+    const { result } = renderManager();
+
+    act(() => {
+      result.current.setSharedTodos([
+        { id: "a", text: "A", isCompleted: false },
+        { id: "b", text: "B", isCompleted: false },
+        { id: "c", text: "C", isCompleted: false },
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.addTodo("新規");
+    });
+
+    expect(result.current.sharedTodos.map((t) => t.text)).toEqual(["新規", "A", "B", "C"]);
+  });
+
+  it("空文字・空白のみのテキストは追加されない", async () => {
+    const { result } = renderManager();
+
+    await act(async () => {
+      await result.current.addTodo("   ");
+    });
+
+    expect(result.current.sharedTodos).toHaveLength(0);
+  });
+
+  // 復元は DB 同期の ON/OFF で経路が分かれる。OFF 側だけ末尾のままだと
+  // 同じ操作なのに表示位置が変わってしまうため、両経路とも先頭に揃える
+  it("ゴミ箱からの復元も先頭に戻る", async () => {
+    const { result } = renderManager();
+
+    act(() => {
+      result.current.setSharedTodos([{ id: "a", text: "A", isCompleted: false }]);
+    });
+
+    act(() => {
+      result.current.restoreTodo({
+        id: "z",
+        text: "復元されたタスク",
+        isCompleted: false,
+        deletedAt: new Date().toISOString(),
+      });
+    });
+
+    expect(result.current.sharedTodos.map((t) => t.text)).toEqual(["復元されたタスク", "A"]);
+  });
+});
+
+describe("新規 TODO は先頭に追加される（Supabase 同期時）", () => {
+  it("既存の最小 order_index より小さい値を採り、全行の振り直しをしない", async () => {
+    const { builder, inserted } = createTodosMock([
+      { id: "a", text: "A", is_completed: false, order_index: 0 },
+      { id: "b", text: "B", is_completed: false, order_index: 1 },
+      { id: "c", text: "C", is_completed: false, order_index: 2 },
+    ]);
+    mockFrom.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useSupabaseTodos(USER));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.addTodo("新規");
+    });
+
+    expect(inserted).toHaveLength(1);
+    // 昇順ソートで先頭に来るには最小値より小さい必要がある
+    expect(inserted[0].order_index).toBe(-1);
+    // 既存行を書き換えていないこと（update を一度も呼んでいない）
+    expect(inserted[0].user_id).toBe(USER.id);
+  });
+
+  it("TODO が 1 件も無ければ order_index は 0 から始まる", async () => {
+    const { builder, inserted } = createTodosMock([]);
+    mockFrom.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useSupabaseTodos(USER));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.addTodo("最初のタスク");
+    });
+
+    expect(inserted[0].order_index).toBe(0);
+  });
+
+  it("負の order_index が既にあっても、さらに小さい値を採る", async () => {
+    const { builder, inserted } = createTodosMock([
+      { id: "a", text: "A", is_completed: false, order_index: -3 },
+      { id: "b", text: "B", is_completed: false, order_index: 5 },
+    ]);
+    mockFrom.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useSupabaseTodos(USER));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.addTodo("新規");
+    });
+
+    expect(inserted[0].order_index).toBe(-4);
+  });
+
+  it("楽観更新でも先頭に差し込む（再取得を待たずに先頭表示される）", async () => {
+    const { builder } = createTodosMock([
+      { id: "a", text: "A", is_completed: false, order_index: 0 },
+    ]);
+    mockFrom.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useSupabaseTodos(USER));
+    await waitFor(() => expect(result.current.todos.map((t) => t.text)).toEqual(["A"]));
+
+    await act(async () => {
+      await result.current.addTodo("新規");
+    });
+
+    expect(result.current.todos.map((t) => t.text)).toEqual(["新規", "A"]);
+  });
+
+  // 別端末・別タブで追加された TODO もリアルタイム購読経由で流れてくる。
+  // ここが末尾追加のままだと、追加した端末と見ている端末で並びが食い違う
+  it("他端末からのリアルタイム INSERT も先頭に入る", async () => {
+    const { builder } = createTodosMock([
+      { id: "a", text: "A", is_completed: false, order_index: 0 },
+    ]);
+    mockFrom.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useSupabaseTodos(USER));
+    await waitFor(() => expect(result.current.todos.map((t) => t.text)).toEqual(["A"]));
+    expect(realtimeHandler).not.toBeNull();
+
+    act(() => {
+      realtimeHandler?.({
+        eventType: "INSERT",
+        new: { id: "z", text: "他端末で追加", is_completed: false, order_index: -1 },
+      });
+    });
+
+    expect(result.current.todos.map((t) => t.text)).toEqual(["他端末で追加", "A"]);
+  });
+});

--- a/components/calendar/bulk-todo-dialog.tsx
+++ b/components/calendar/bulk-todo-dialog.tsx
@@ -89,7 +89,9 @@ export function BulkTodoDialog({
     const unlinked: string[] = [];
 
     try {
-      for (const event of targets) {
+      // TODO は 1 件ずつ先頭に積まれるため、時系列の逆順で作ると
+      // 結果として画面上は元の時系列（早い予定が上）に並ぶ
+      for (const event of [...targets].reverse()) {
         const start = eventDisplayDate(event.startAt, event.isAllDay);
         const dueDate = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-${String(start.getDate()).padStart(2, "0")}`;
         const dueTime = event.isAllDay ? undefined : start.toTimeString().slice(0, 5);

--- a/hooks/useSupabaseTodos.ts
+++ b/hooks/useSupabaseTodos.ts
@@ -90,15 +90,20 @@ export function useSupabaseTodos(user: User | null) {
     if (!user) return null
 
     try {
-      // DBから現在のTODO件数を取得（他クライアントからの同時追加にも対応）
-      const { count, error: countError } = await supabase
+      // 先頭に差し込むため、DB 上の最小 order_index より 1 小さい値を採る。
+      // 既存行の振り直しが不要（更新 1 件で済む）で、他クライアントからの
+      // 同時追加でもローカル state ではなく DB を見るので取りこぼさない
+      const { data: firstRow, error: minError } = await supabase
         .from("todos")
-        .select("*", { count: "exact", head: true })
+        .select("order_index")
         .eq("user_id", user.id)
+        .order("order_index", { ascending: true })
+        .limit(1)
+        .maybeSingle()
 
-      if (countError) throw countError
+      if (minError) throw minError
 
-      const orderIndex = count ?? 0
+      const orderIndex = firstRow ? firstRow.order_index - 1 : 0
 
       const { data, error } = await supabase
         .from("todos")
@@ -116,7 +121,7 @@ export function useSupabaseTodos(user: User | null) {
       if (error) throw error
 
       if (data) {
-        setTodos(prev => [...prev, convertToLocal(data)])
+        setTodos(prev => [convertToLocal(data), ...prev])
         return data.id
       }
       return null
@@ -262,7 +267,8 @@ export function useSupabaseTodos(user: User | null) {
           switch (payload.eventType) {
             case 'INSERT':
               if (payload.new) {
-                setTodos((prev) => [...prev, convertToLocal(payload.new as SupabaseTodoItem)])
+                // 他端末での追加も先頭に入れないと、追加した端末と並びが食い違う
+                setTodos((prev) => [convertToLocal(payload.new as SupabaseTodoItem), ...prev])
               }
               break
             case 'UPDATE':

--- a/hooks/useTodoManager.ts
+++ b/hooks/useTodoManager.ts
@@ -274,7 +274,8 @@ export function useTodoManager(options: TodoManagerOptions): TodoManagerState {
           dueDate: options?.dueDate,
           dueTime: options?.dueTime,
         };
-        setSharedTodos((prev) => [...prev, newTodo]);
+        // 新規 TODO は先頭に置く（長いリストで末尾に埋もれて見失うのを防ぐ）
+        setSharedTodos((prev) => [newTodo, ...prev]);
         return newId;
       }
     },
@@ -361,7 +362,8 @@ export function useTodoManager(options: TodoManagerOptions): TodoManagerState {
       if (useDatabase && user) {
         sharedSupabaseTodos.addTodo(todoItem.text);
       } else {
-        setSharedTodos((prev) => [...prev, todoItem]);
+        // DB 経路（addTodo）が先頭に入れるので、ローカル経路も揃える
+        setSharedTodos((prev) => [todoItem, ...prev]);
       }
       setTrashedTodos((prev) => prev.filter((t) => t.id !== trashedTodo.id));
     },


### PR DESCRIPTION
## 変更内容

長いリストでは末尾に追加された TODO が画面外に埋もれ、追加した直後に見失う。新規追加を先頭に置くようにした。

## 追加経路が4つあった

「先頭に追加」は一見1行の変更に見えるが、TODO の追加経路は4つあり、1箇所だけ直すと経路によって挙動が食い違う。すべて揃えた。

| # | 場所 | 変更前 | 変更後 |
|---|---|---|---|
| 1 | `useTodoManager.addTodo`（ローカル保存） | `[...prev, new]` | `[new, ...prev]` |
| 2 | `useTodoManager.restoreTodo`（ゴミ箱復元・ローカル経路） | `[...prev, item]` | `[item, ...prev]` |
| 3 | `useSupabaseTodos.addTodo` の `order_index` | 件数（= 最大値） | **最小値 − 1** |
| 4 | `useSupabaseTodos` リアルタイム購読の INSERT | `[...prev, new]` | `[new, ...prev]` |

**2 が必要な理由**: 復元は DB 同期の ON/OFF で経路が分かれる。ON 側は `addTodo` を呼ぶので 1 の修正で先頭に入るが、OFF 側は独立した実装で末尾のままだった。同じ操作なのにトグルの状態で表示位置が変わってしまう。

**3 の設計**: 全行の `order_index` を振り直す案もあるが、更新が N 件になり競合しやすい。最小値 − 1 なら更新は挿入 1 件だけで済む。負の値が増えるが、ドラッグ&ドロップ時の `reorderTodos` が 0..n-1 に正規化するので発散しない。ローカル state ではなく DB を見ているので、他クライアントからの同時追加でも取りこぼさない（変更前の「件数を採る」実装が持っていた性質を維持）。

**4 が必要な理由**: 別端末・別タブでの追加はリアルタイム購読経由で流れてくる。ここが末尾のままだと、追加した端末では先頭・見ている端末では末尾、と並びが食い違う。

## 一括 TODO 化への波及

予定の一括 TODO 化は 1 件ずつ順に作るため、先頭挿入だと画面上の時系列が反転する（月→水→金 で作ると 金→水→月 と並ぶ）。逆順にループして、積み上がった結果が元の時系列になるようにした。

## テスト

新規 10 件（`__tests__/todo-order.test.tsx` 9 件 + `__tests__/bulk-todo-order.test.tsx` 1 件）。

### ミューテーションテスト

テストに歯があることを、修正を意図的に元に戻して確認した。

| 戻した修正 | 結果 |
|---|---|
| 4箇所すべてを末尾追加に戻す | **9 件中 7 件が失敗**。残り 2 件は順序に依存しない（空文字ガード、0 件時の初期値 0） |
| 一括 TODO 化の逆順ループを戻す | **1 件失敗** |

いずれも復元後にグリーンを再確認済み。

### 既存テストの修正

`__tests__/supabase-integration.test.tsx` の `addTodo` テストが落ちた。`addTodo` が新たに投げる「最小 order_index 取得」クエリを Supabase モックが知らず、`.limit()` が存在せず例外になっていたため。モックに `limit` / `maybeSingle` を追加した（既存行 0 件を返すので `order_index: 0` という元の検証意図はそのまま）。

## 検証結果

```
Test Suites: 20 passed, 20 total
Tests:       3 skipped, 387 passed, 390 total
npx tsc --noEmit  → エラー 0
npm run build     → 成功
```

## ベースブランチについて

`main` ではなく **#61 のブランチ (`test/api-test-hardening`) をベースにしている**。`main` の jest 設定は swiper 導入時のまま壊れており、テストが実行できないため。**#61 を先にマージしてから、このPRのベースを `main` に切り替えてください。**

## 未検証

実機ブラウザでの確認はしていない。「追加した TODO が画面の先頭に現れる」ことと、DB 同期 ON で他端末との並びが一致することは実機で見てほしい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
