### PR TITLE
refactor: hooks と lib の any / console.log を一掃（挙動不変）

### DIFF
--- a/hooks/useAlarmSystem.ts
+++ b/hooks/useAlarmSystem.ts
@@ -332,7 +332,7 @@ export function useAlarmSystem(): AlarmSystem {
     if (typeof window === "undefined") return;
 
     if (!("Notification" in window) || !window.Notification) {
-      console.log("このブラウザでは通知機能が利用できません");
+      console.warn("このブラウザでは通知機能が利用できません");
       return;
     }
 
@@ -347,10 +347,10 @@ export function useAlarmSystem(): AlarmSystem {
             icon: "/favicon.svg",
           });
         } catch (e) {
-          console.log("通知の送信に失敗しました:", e);
+          console.error("通知の送信に失敗しました:", e);
         }
       } else if (permission === "denied") {
-        console.log("通知が拒否されました");
+        console.warn("通知が拒否されました");
       }
     } catch (error) {
       console.error("通知権限のリクエストに失敗しました:", error);

--- a/hooks/useKanbanStatuses.ts
+++ b/hooks/useKanbanStatuses.ts
@@ -309,8 +309,7 @@ export function useKanbanStatuses(user: User | null) {
           table: "kanban_statuses",
           filter: `user_id=eq.${user.id}`,
         },
-        (payload) => {
-          console.log("Kanban status change received, refetching:", payload)
+        () => {
           fetchStatuses()
         }
       )

--- a/hooks/useMultipleMemos.ts
+++ b/hooks/useMultipleMemos.ts
@@ -22,13 +22,11 @@ function createNewMemo(): MemoData {
 // ローカルストレージからメモを取得
 function getLocalMemos(): MemoData[] {
   if (typeof window === "undefined") {
-    console.log("[useMultipleMemos] getLocalMemos: window is undefined (SSR)")
     return []
   }
   try {
     const saved = localStorage.getItem(LOCAL_STORAGE_KEY)
     const memos = saved ? JSON.parse(saved) : []
-    console.log("[useMultipleMemos] getLocalMemos: retrieved", memos.length, "memos")
     return memos
   } catch (error) {
     console.error("[useMultipleMemos] getLocalMemos error:", error)
@@ -39,13 +37,11 @@ function getLocalMemos(): MemoData[] {
 // ローカルストレージにメモを保存
 function saveLocalMemos(memos: MemoData[]) {
   if (typeof window === "undefined") {
-    console.log("[useMultipleMemos] saveLocalMemos: window is undefined (SSR)")
     return
   }
   try {
     const data = JSON.stringify(memos)
     localStorage.setItem(LOCAL_STORAGE_KEY, data)
-    console.log("[useMultipleMemos] saveLocalMemos: saved", memos.length, "memos, size:", data.length, "bytes")
   } catch (error) {
     console.error("[useMultipleMemos] saveLocalMemos error:", error)
   }
@@ -86,8 +82,9 @@ export function useMultipleMemos(user: User | null, useDatabase: boolean) {
                 const localMemos = getLocalMemos()
                 setMemos(localMemos)
             }
-        } catch (err: any) {
-            setError(err.message)
+        } catch (err) {
+            // any 禁止規約対応: catch は unknown で受け、Error へ narrowing してメッセージを取り出す（以降の catch も同様）
+            setError(err instanceof Error ? err.message : String(err))
             console.error('Error fetching memos:', err)
             // フォールバック: ローカルストレージ
             const localMemos = getLocalMemos()
@@ -139,8 +136,8 @@ export function useMultipleMemos(user: User | null, useDatabase: boolean) {
                 })
                 return newMemo
             }
-        } catch (err: any) {
-            setError(err.message)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
             console.error('Error creating memo:', err)
             return null
         }
@@ -182,8 +179,8 @@ export function useMultipleMemos(user: User | null, useDatabase: boolean) {
 
                     return updatedMemos
                 })
-            } catch (err: any) {
-                setError(err.message)
+            } catch (err) {
+                setError(err instanceof Error ? err.message : String(err))
                 console.error('Error updating memo:', err)
             }
         },
@@ -222,8 +219,8 @@ export function useMultipleMemos(user: User | null, useDatabase: boolean) {
 
                     return updatedMemos
                 })
-            } catch (err: any) {
-                setError(err.message)
+            } catch (err) {
+                setError(err instanceof Error ? err.message : String(err))
                 console.error('Error deleting memo:', err)
             }
         },
@@ -261,8 +258,8 @@ export function useMultipleMemos(user: User | null, useDatabase: boolean) {
 
                     return updatedMemos
                 })
-            } catch (err: any) {
-                setError(err.message)
+            } catch (err) {
+                setError(err instanceof Error ? err.message : String(err))
                 console.error('Error restoring memo:', err)
             }
         },
@@ -289,8 +286,6 @@ export function useMultipleMemos(user: User | null, useDatabase: boolean) {
                     filter: `user_id=eq.${user.id}`,
                 },
                 (payload) => {
-                    console.log('Memo change received:', payload)
-
                     switch (payload.eventType) {
                         case 'INSERT':
                             if (payload.new) {
@@ -374,7 +369,7 @@ export function useMultipleMemos(user: User | null, useDatabase: boolean) {
                     if (reorderError) {
                         throw reorderError
                     }
-                } catch (err: any) {
+                } catch (err) {
                     console.error('Error reordering memos:', err)
                     setError('メモの順序の保存に失敗しました。')
                     setMemos(originalMemos)

--- a/hooks/useSupabasePomodoroTask.ts
+++ b/hooks/useSupabasePomodoroTask.ts
@@ -130,8 +130,6 @@ export function useSupabasePomodoroTask(user: User | null) {
           filter: `user_id=eq.${user.id}`,
         },
         (payload) => {
-          console.log("Pomodoro task change received:", payload)
-
           switch (payload.eventType) {
             case "INSERT":
             case "UPDATE":

--- a/hooks/useSupabaseTags.ts
+++ b/hooks/useSupabaseTags.ts
@@ -162,8 +162,6 @@ export function useSupabaseTags(user: User | null) {
           filter: `user_id=eq.${user.id}`,
         },
         (payload) => {
-          console.log("Tag change received:", payload)
-
           switch (payload.eventType) {
             case 'INSERT':
               if (payload.new) {

--- a/hooks/useSupabaseTodos.ts
+++ b/hooks/useSupabaseTodos.ts
@@ -77,8 +77,9 @@ export function useSupabaseTodos(user: User | null) {
       if (error) throw error
 
       setTodos((data || []).map(convertToLocal))
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      // any 禁止規約対応: catch は unknown で受け、Error へ narrowing してメッセージを取り出す（以降の catch も同様）
+      setError(err instanceof Error ? err.message : String(err))
       console.error("Error fetching todos:", err)
     } finally {
       setLoading(false)
@@ -125,8 +126,8 @@ export function useSupabaseTodos(user: User | null) {
         return data.id
       }
       return null
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
       console.error("Error adding todo:", err)
       return null
     }
@@ -152,8 +153,8 @@ export function useSupabaseTodos(user: User | null) {
 
       // ローカル状態は常に更新（関数形式で最新の状態を参照）
       setTodos(prev => prev.map((todo) => (todo.id === id ? { ...todo, ...updates } : todo)))
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
       console.error("Error updating todo:", err)
     }
   }
@@ -172,8 +173,8 @@ export function useSupabaseTodos(user: User | null) {
       if (error) throw error
 
       setTodos(prev => prev.filter((todo) => todo.id !== id))
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
       console.error("Error removing todo:", err)
     }
   }
@@ -195,8 +196,8 @@ export function useSupabaseTodos(user: User | null) {
       if (!todoToToggle) return
 
       await updateTodo(id, { isCompleted: !todoToToggle.is_completed })
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
       console.error("Error toggling todo:", err)
     }
   }
@@ -233,8 +234,8 @@ export function useSupabaseTodos(user: User | null) {
         // エラー時はリフレッシュして正しい順序を復元
         await fetchTodos()
       }
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
       console.error("Error reordering todos:", err)
       // エラー時はリフレッシュして正しい順序を復元
       await fetchTodos()
@@ -261,7 +262,6 @@ export function useSupabaseTodos(user: User | null) {
           filter: `user_id=eq.${user.id}`,
         },
         (payload) => {
-          console.log("Todo change received:", payload)
 
           // payloadを使って効率的にローカルstateを更新
           switch (payload.eventType) {

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -6,7 +6,12 @@
  */
 
 import OpenAI from 'openai';
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+// any 禁止規約対応: リクエストボディを SDK の公式型で受ける（互換レイヤの動的フィールドも型に含まれる）
+import type {
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+  ChatCompletionMessageParam,
+} from 'openai/resources/chat/completions';
 
 // OpenAIクライアントのシングルトンインスタンス
 let openaiClient: OpenAI | null = null;
@@ -119,8 +124,7 @@ export async function chatCompletion(
     : options.messages;
 
   // APIリクエストボディの構築（互換レイヤ）
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const requestBody: any = {
+  const requestBody: ChatCompletionCreateParamsNonStreaming = {
     model,
     messages,
   };
@@ -172,8 +176,7 @@ export async function* chatCompletionStream(
     : options.messages;
 
   // ストリーミング用のパラメータを構築
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const params: any = {
+  const params: ChatCompletionCreateParamsStreaming = {
     model,
     messages,
     stream: true as const,


### PR DESCRIPTION
## 概要

CLAUDE.md 規約（`any` 禁止 / `console.log` の commit 禁止）への準拠。リファクタリング計画のフェーズ1（機械的整地・挙動不変）。

## 変更内容（7ファイル、+37 / −44）

| 種別 | 箇所 | 対応 |
|---|---|---|
| `catch (err: any)` ×12 | useSupabaseTodos ×6 / useMultipleMemos ×6 | `catch (err)` + `instanceof Error` narrowing（模範実装 `useTodoEventLinks.ts` の方式） |
| realtime 購読の "change received" ログ ×4 | useSupabaseTodos / useMultipleMemos / useSupabaseTags / useSupabasePomodoroTask | 削除（DB イベント毎に出るスパム） |
| デバッグログ ×4 | useMultipleMemos（SSR 判定・保存件数） | 削除 |
| 通知系ログ ×3 | useAlarmSystem | 深刻度を正しく `console.warn` ×2 / `console.error` ×1 へ（エラー経路の診断情報は保持） |
| refetch ログ ×1 | useKanbanStatuses | 削除（`payload` が未使用になるため引数も除去） |
| `: any` ×2 | lib/openai.ts | SDK 公式型 `ChatCompletionCreateParamsNonStreaming` / `Streaming`（`eslint-disable` も除去） |

`useSupabaseMemos.ts` は対象外（本番 import ゼロの死蔵確定・別 PR で削除予定）。

## 挙動不変の証明

- **削除行の全数監査**: diff で消えた行はすべて console.log / `catch (err: any)` / eslint-disable / 旧型注釈 / 削除ログ直後の空行×3 のみ。ロジック行の削除ゼロ
- grep 残存 0 件（hooks の catch-any / console.log、lib の `: any`）
- `tsc --noEmit` エラー 0 / lint エラー 0 / build 成功
- テスト **20 suites / 387 passed / 3 skipped**（ベースライン完全維持）

## 補足

- narrowing (`err instanceof Error ? err.message : String(err)`) について: supabase-js v2 の `PostgrestError` は `Error` を継承するため、UI に出るエラーメッセージは従来と同一
- ベース: `fix/todo-prepend`（#62）。main の jest 設定が壊れているため、テスト実行可能なスタック上に積んでいます。**マージ順: #61 → #62 → 本 PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
