### PR TITLE
refactor(types): Phase 2 — LocalTodoItem 移動・UUID_REGEX 一元化・AnnotationInput Omit 導出

### DIFF
--- a/app/api/v1/calendar/events/[eventKey]/annotation/route.ts
+++ b/app/api/v1/calendar/events/[eventKey]/annotation/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { authenticateRequest, handleCors, apiResponse, apiError } from "@/lib/api-auth";
+import { UUID_REGEX } from "@/lib/validation";
 import type { EventAnnotation } from "@/types/calendar";
 
 export async function OPTIONS() {
@@ -47,9 +48,8 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
     : "instance";
   const memo = typeof input.memo === "string" ? input.memo : null;
   // tag_ids カラムは uuid[] のため、不正な値は upsert 前に除外する
-  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const tagIds = Array.isArray(input.tagIds)
-    ? input.tagIds.filter((id): id is string => typeof id === "string" && uuidRegex.test(id))
+    ? input.tagIds.filter((id): id is string => typeof id === "string" && UUID_REGEX.test(id))
     : [];
 
   const { data, error } = await auth.supabase

--- a/app/api/v1/calendar/todo-links/route.ts
+++ b/app/api/v1/calendar/todo-links/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { UUID_REGEX } from "@/lib/validation";
 import { authenticateRequest, handleCors, apiResponse, apiError } from "@/lib/api-auth";
 
 export async function OPTIONS() {
@@ -31,8 +32,8 @@ export async function POST(request: NextRequest) {
 
   // todo_id カラムは uuid のため、非 UUID を渡すと Postgres が 22P02 を投げ、
   // クライアント側の入力ミスが 500 として返ってしまう
-  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  if (!uuidRegex.test(todoId)) {
+
+  if (!UUID_REGEX.test(todoId)) {
     return apiError("todoId must be a valid UUID", 400);
   }
 

--- a/components/calendar/calendar-tab.tsx
+++ b/components/calendar/calendar-tab.tsx
@@ -30,7 +30,7 @@ import { CalendarAgendaView } from "./calendar-agenda-view";
 import { EventDetailDrawer } from "./event-detail-drawer";
 import { BulkTodoDialog } from "./bulk-todo-dialog";
 import type { CalendarEvent, CalendarViewType } from "@/types/calendar";
-import type { LocalTodoItem } from "@/hooks/useSupabaseTodos";
+import type { LocalTodoItem } from "@/types";
 
 type CalendarTabProps = {
   user: User | null;

--- a/components/calendar/event-detail-drawer.tsx
+++ b/components/calendar/event-detail-drawer.tsx
@@ -17,7 +17,7 @@ import { useEventAnnotations } from "@/hooks/useEventAnnotations";
 import { useTodoEventLinks } from "@/hooks/useTodoEventLinks";
 import type { CalendarEvent, AnnotationScope } from "@/types/calendar";
 import type { PriorityLevel, ImportanceLevel } from "@/types";
-import type { LocalTodoItem } from "@/hooks/useSupabaseTodos";
+import type { LocalTodoItem } from "@/types";
 
 type EventDetailDrawerProps = {
   event: CalendarEvent | null;

--- a/components/deadline-timeline.tsx
+++ b/components/deadline-timeline.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from "react";
 import { Play, Clock, ArrowRight, Target } from "lucide-react";
-import type { LocalTodoItem } from "@/hooks/useSupabaseTodos";
+import type { LocalTodoItem } from "@/types";
 
 type DeadlineTimelineProps = {
   todos: LocalTodoItem[];

--- a/hooks/useSupabaseTodos.ts
+++ b/hooks/useSupabaseTodos.ts
@@ -3,25 +3,10 @@
 import { useState, useEffect } from "react"
 import { supabase, type TodoItem as SupabaseTodoItem } from "@/lib/supabase"
 import type { User } from "@supabase/supabase-js"
+import type { LocalTodoItem, PriorityLevel, ImportanceLevel, KanbanStatus } from "@/types"
 
-// 優先度・重要度・カンバンステータスの型
-type PriorityLevel = "high" | "medium" | "low" | "none"
-type ImportanceLevel = "high" | "medium" | "low" | "none"
-type KanbanStatus = string // 動的ステータスに対応するため文字列型
-
-// ローカル用のTodo型（既存のcomm-time.tsxと互換性を保つ）
-export type LocalTodoItem = {
-  id: string
-  text: string
-  isCompleted: boolean
-  dueDate?: string
-  dueTime?: string
-  alarmPointId?: string
-  tagIds?: string[]
-  priority?: PriorityLevel
-  importance?: ImportanceLevel
-  kanbanStatus?: KanbanStatus
-}
+// LocalTodoItem は @/types から re-export（後方互換のため）
+export type { LocalTodoItem }
 
 export function useSupabaseTodos(user: User | null) {
   const [todos, setTodos] = useState<LocalTodoItem[]>([])

--- a/lib/calendar-api.ts
+++ b/lib/calendar-api.ts
@@ -80,13 +80,8 @@ export async function fetchCalendarEvents(from: string, to: string): Promise<Cal
   return events;
 }
 
-export type AnnotationInput = {
-  scope: AnnotationScope;
-  memo?: string;
-  priority: PriorityLevel;
-  importance: ImportanceLevel;
-  tagIds: string[];
-};
+// EventAnnotation から eventKey を除いたもの（送信ペイロード）
+export type AnnotationInput = Omit<EventAnnotation, "eventKey">;
 
 export async function saveEventAnnotation(
   eventKey: string,

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,2 @@
+// UUID v4 形式の検証 regex（Postgres uuid 型の事前バリデーション用）
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/types/index.ts
+++ b/types/index.ts
@@ -39,6 +39,20 @@ export type TodoItem = {
   kanbanStatus?: KanbanStatus; // カンバンステータス
 };
 
+// Supabase/ローカル両対応の TODO 型（alarmPointId を含む）
+export type LocalTodoItem = {
+  id: string;
+  text: string;
+  isCompleted: boolean;
+  dueDate?: string;
+  dueTime?: string;
+  alarmPointId?: string;
+  tagIds?: string[];
+  priority?: PriorityLevel;
+  importance?: ImportanceLevel;
+  kanbanStatus?: KanbanStatus;
+};
+
 // ゴミ箱に入ったTODOの型
 export type TrashedTodoItem = TodoItem & {
   deletedAt: string; // ISO形式の日時


### PR DESCRIPTION
## Summary

- **ST2-1**: `LocalTodoItem` 型を `hooks/useSupabaseTodos.ts` から `types/index.ts` へ移動。hooks ファイルパスは変更せず後方互換 `re-export` を維持。3 コンポーネントのインポートを `@/hooks/useSupabaseTodos` → `@/types` に更新
- **ST2-2**: UUID regex を `lib/validation.ts` に一元化。2 ルートの重複定義を削除
- **ST2-3**: `AnnotationInput` を手書き複製から `Omit<EventAnnotation, "eventKey">` に置換

## Verification

- `npx tsc --noEmit` → exit 0
- `npm test` → 20 suites / 387 passed / 3 skipped (ベースライン維持)
- ミューテーションテスト(ST2-2): `UUID_REGEX` を破壊 → `calendar-routes` 5 件 FAIL 確認 → revert 後 PASS

## Stacking

PR chain: `fix/todo-prepend` ← `refactor/no-any-no-console` (PR-1) ← **この PR** (PR-2) ← Phase 3 以降

🤖 Generated with [Claude Code](https://claude.com/claude-code)