### PR TITLE
refactor(phase6): unify color map, move value constants from types to lib/constants

### DIFF
--- a/__tests__/kanban-statuses.test.tsx
+++ b/__tests__/kanban-statuses.test.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { User } from '@supabase/supabase-js';
-import { type KanbanStatusColumn, DEFAULT_KANBAN_COLUMNS } from '@/types';
+import type { KanbanStatusColumn } from '@/types';
+import { DEFAULT_KANBAN_COLUMNS } from '@/lib/constants';
 
 // isSupabaseConfiguredのモック用フラグ
 let mockIsConfigured = true;

--- a/__tests__/todo-list-panel.test.tsx
+++ b/__tests__/todo-list-panel.test.tsx
@@ -8,7 +8,7 @@ import userEvent from "@testing-library/user-event";
 import { TodoListPanel } from "../components/todo-list/TodoListPanel";
 import type { TodoListPanelProps } from "../components/todo-list/TodoListPanel";
 import type { TodoItem, TrashedTodoItem, FilterState } from "../types";
-import { initialFilterState } from "../types";
+import { initialFilterState } from "../lib/constants";
 
 // Heavy deps that need jsdom-safe mocks
 jest.mock("../components/strict-mode-droppable", () => ({

--- a/components/filter-panel.tsx
+++ b/components/filter-panel.tsx
@@ -2,18 +2,20 @@
 
 import React from "react";
 import { X, Filter, Tag as TagIcon, Flag, Star, Columns } from "lucide-react";
+import type {
+  Tag,
+  FilterState,
+  PriorityLevel,
+  ImportanceLevel,
+  KanbanStatus,
+  KanbanStatusColumn,
+} from "@/types";
 import {
-  type Tag,
-  type FilterState,
-  type PriorityLevel,
-  type ImportanceLevel,
-  type KanbanStatus,
-  type KanbanStatusColumn,
   PRIORITY_CONFIG,
   IMPORTANCE_CONFIG,
   DEFAULT_KANBAN_COLUMNS,
   TAG_COLORS,
-} from "@/types";
+} from "@/lib/constants";
 
 interface FilterPanelProps {
   tags: Tag[];

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -14,17 +14,19 @@ import {
   Clock,
 } from "lucide-react";
 import { RichTextWithLinks } from "@/components/rich-text-with-links";
+import type {
+  Tag,
+  KanbanStatus,
+  KanbanStatusColumn,
+  PriorityLevel,
+  ImportanceLevel,
+} from "@/types";
 import {
-  type Tag,
-  type KanbanStatus,
-  type KanbanStatusColumn,
-  type PriorityLevel,
-  type ImportanceLevel,
   DEFAULT_KANBAN_COLUMNS,
   PRIORITY_CONFIG,
   IMPORTANCE_CONFIG,
   TAG_COLORS,
-} from "@/types";
+} from "@/lib/constants";
 
 // TODO型の最小定義（comm-time.tsxから渡される）
 interface TodoItem {

--- a/components/kanban-status-manager.tsx
+++ b/components/kanban-status-manager.tsx
@@ -16,10 +16,8 @@ import {
   type DropResult,
 } from "react-beautiful-dnd";
 import { StrictModeDroppable } from "@/components/strict-mode-droppable";
-import {
-  type KanbanStatusColumn,
-  KANBAN_STATUS_COLORS,
-} from "@/types";
+import type { KanbanStatusColumn } from "@/types";
+import { KANBAN_STATUS_COLORS } from "@/lib/constants";
 
 interface KanbanStatusManagerProps {
   statuses: KanbanStatusColumn[];

--- a/components/tag-manager.tsx
+++ b/components/tag-manager.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState } from "react";
 import { Plus, X, Edit, Trash2, Save, Tag as TagIcon } from "lucide-react";
-import { type Tag, TAG_COLORS } from "@/types";
+import type { Tag } from "@/types";
+import { TAG_COLORS } from "@/lib/constants";
 
 interface TagManagerProps {
   tags: Tag[];

--- a/components/todo-edit-dialog.tsx
+++ b/components/todo-edit-dialog.tsx
@@ -3,16 +3,18 @@
 import React, { useState, useEffect } from "react";
 import { X, Save, Tag as TagIcon, Flag, Star, Columns } from "lucide-react";
 import { RichTextWithLinks } from "@/components/rich-text-with-links";
+import type {
+  Tag,
+  PriorityLevel,
+  ImportanceLevel,
+  KanbanStatus,
+} from "@/types";
 import {
-  type Tag,
-  type PriorityLevel,
-  type ImportanceLevel,
-  type KanbanStatus,
   PRIORITY_CONFIG,
   IMPORTANCE_CONFIG,
   KANBAN_COLUMNS,
   TAG_COLORS,
-} from "@/types";
+} from "@/lib/constants";
 
 interface TodoItem {
   id: string;

--- a/components/todo-list/TodoMetaBadges.tsx
+++ b/components/todo-list/TodoMetaBadges.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { Flag, Star } from "lucide-react";
 import type { TodoItem, Tag, KanbanStatusColumn } from "@/types";
-import { PRIORITY_CONFIG, IMPORTANCE_CONFIG, TAG_COLORS } from "@/types";
+import { PRIORITY_CONFIG, IMPORTANCE_CONFIG, TAG_COLORS } from "@/lib/constants";
 
 interface TodoMetaBadgesProps {
   todo: TodoItem;

--- a/hooks/useKanbanStatuses.ts
+++ b/hooks/useKanbanStatuses.ts
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback } from "react"
 import { supabase, isSupabaseConfigured } from "@/lib/supabase"
 import type { User } from "@supabase/supabase-js"
-import { type KanbanStatusColumn, DEFAULT_KANBAN_COLUMNS } from "@/types"
+import type { KanbanStatusColumn } from "@/types"
+import { DEFAULT_KANBAN_COLUMNS } from "@/lib/constants"
 
 // DBの型からローカル型に変換
 const convertToLocal = (dbStatus: Record<string, unknown>): KanbanStatusColumn => ({

--- a/hooks/useTodoFilters.ts
+++ b/hooks/useTodoFilters.ts
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import type { TodoItem, FilterState } from "@/types";
-import { initialFilterState } from "@/types";
+import { initialFilterState } from "@/lib/constants";
 
 type TodoFiltersOptions = {
   sharedTodos: TodoItem[];

--- a/lib/calendar-api.ts
+++ b/lib/calendar-api.ts
@@ -8,7 +8,6 @@ import type {
   EventAnnotation,
   AnnotationScope,
 } from "@/types/calendar";
-import type { PriorityLevel, ImportanceLevel } from "@/types";
 
 class CalendarApiError extends Error {
   constructor(

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,12 @@
-import type { AlarmPoint, AlarmSettings, PomodoroSettings } from "@/types";
+import type {
+  AlarmPoint,
+  AlarmSettings,
+  PomodoroSettings,
+  KanbanStatusColumn,
+  PriorityLevel,
+  ImportanceLevel,
+  FilterState,
+} from "@/types";
 
 // ミーティングタイマーの初期アラームポイント
 export const INITIAL_MEETING_ALARM_POINTS: AlarmPoint[] = [
@@ -109,3 +117,70 @@ export const CALENDAR_TEXT = {
   connectedToast: "Google カレンダーを連携しました",
   connectErrorToast: "Google カレンダーの連携に失敗しました",
 } as const;
+
+// ---
+// TODO / カンバン / タグ 定数（types/index.ts から移動）
+// ---
+
+// 優先度・重要度設定の共通型（PRIORITY_CONFIG と IMPORTANCE_CONFIG は値が同一）
+type LevelConfig = {
+  label: string;
+  color: string;
+  icon: string;
+  bgClass: string;
+  textClass: string;
+  badgeClass: string;
+  activeClass: string;
+};
+
+const LEVEL_CONFIG: Record<PriorityLevel, LevelConfig> = {
+  high: { label: "高", color: "red", icon: "", bgClass: "bg-red-500", textClass: "text-red-600", badgeClass: "bg-red-100 text-red-700", activeClass: "bg-red-500 text-white" },
+  medium: { label: "中", color: "yellow", icon: "", bgClass: "bg-yellow-500", textClass: "text-yellow-600", badgeClass: "bg-yellow-100 text-yellow-700", activeClass: "bg-yellow-500 text-black" },
+  low: { label: "低", color: "blue", icon: "", bgClass: "bg-blue-500", textClass: "text-blue-600", badgeClass: "bg-blue-100 text-blue-700", activeClass: "bg-blue-500 text-white" },
+  none: { label: "-", color: "gray", icon: "", bgClass: "bg-gray-500", textClass: "text-gray-600", badgeClass: "bg-gray-100 text-gray-700", activeClass: "bg-gray-500 text-white" },
+};
+
+export const PRIORITY_CONFIG: Record<PriorityLevel, LevelConfig> = LEVEL_CONFIG;
+export const IMPORTANCE_CONFIG: Record<ImportanceLevel, LevelConfig> = LEVEL_CONFIG;
+
+export const KANBAN_STATUS_COLORS = [
+  { name: "グレー", color: "gray", bgClass: "bg-gray-500", textClass: "text-gray-600", borderClass: "border-gray-300", activeClass: "bg-gray-500 text-white" },
+  { name: "ブルー", color: "blue", bgClass: "bg-blue-500", textClass: "text-blue-600", borderClass: "border-blue-300", activeClass: "bg-blue-500 text-white" },
+  { name: "イエロー", color: "yellow", bgClass: "bg-yellow-500", textClass: "text-yellow-600", borderClass: "border-yellow-300", activeClass: "bg-yellow-500 text-black" },
+  { name: "グリーン", color: "green", bgClass: "bg-green-500", textClass: "text-green-600", borderClass: "border-green-300", activeClass: "bg-green-500 text-white" },
+  { name: "レッド", color: "red", bgClass: "bg-red-500", textClass: "text-red-600", borderClass: "border-red-300", activeClass: "bg-red-500 text-white" },
+  { name: "オレンジ", color: "orange", bgClass: "bg-orange-500", textClass: "text-orange-600", borderClass: "border-orange-300", activeClass: "bg-orange-500 text-white" },
+  { name: "パープル", color: "purple", bgClass: "bg-purple-500", textClass: "text-purple-600", borderClass: "border-purple-300", activeClass: "bg-purple-500 text-white" },
+  { name: "ピンク", color: "pink", bgClass: "bg-pink-500", textClass: "text-pink-600", borderClass: "border-pink-300", activeClass: "bg-pink-500 text-white" },
+  { name: "インディゴ", color: "indigo", bgClass: "bg-indigo-500", textClass: "text-indigo-600", borderClass: "border-indigo-300", activeClass: "bg-indigo-500 text-white" },
+  { name: "ティール", color: "teal", bgClass: "bg-teal-500", textClass: "text-teal-600", borderClass: "border-teal-300", activeClass: "bg-teal-500 text-white" },
+];
+
+export const TAG_COLORS = [
+  { name: "レッド", value: "bg-red-500", textColor: "text-white" },
+  { name: "オレンジ", value: "bg-orange-500", textColor: "text-white" },
+  { name: "イエロー", value: "bg-yellow-500", textColor: "text-black" },
+  { name: "グリーン", value: "bg-green-500", textColor: "text-white" },
+  { name: "ブルー", value: "bg-blue-500", textColor: "text-white" },
+  { name: "インディゴ", value: "bg-indigo-500", textColor: "text-white" },
+  { name: "パープル", value: "bg-purple-500", textColor: "text-white" },
+  { name: "ピンク", value: "bg-pink-500", textColor: "text-white" },
+  { name: "グレー", value: "bg-gray-500", textColor: "text-white" },
+  { name: "ティール", value: "bg-teal-500", textColor: "text-white" },
+];
+
+export const DEFAULT_KANBAN_COLUMNS: KanbanStatusColumn[] = [
+  { id: "backlog", user_id: "", name: "backlog", label: "Backlog", color: "gray", bgClass: "bg-gray-500", textClass: "text-gray-600", borderClass: "border-gray-300", activeClass: "bg-gray-500 text-white", sortOrder: 0, isDefault: true },
+  { id: "todo", user_id: "", name: "todo", label: "Todo", color: "blue", bgClass: "bg-blue-500", textClass: "text-blue-600", borderClass: "border-blue-300", activeClass: "bg-blue-500 text-white", sortOrder: 1, isDefault: false },
+  { id: "doing", user_id: "", name: "doing", label: "Doing", color: "yellow", bgClass: "bg-yellow-500", textClass: "text-yellow-600", borderClass: "border-yellow-300", activeClass: "bg-yellow-500 text-black", sortOrder: 2, isDefault: false },
+  { id: "done", user_id: "", name: "done", label: "Done", color: "green", bgClass: "bg-green-500", textClass: "text-green-600", borderClass: "border-green-300", activeClass: "bg-green-500 text-white", sortOrder: 3, isDefault: false },
+];
+
+export const KANBAN_COLUMNS = DEFAULT_KANBAN_COLUMNS;
+
+export const initialFilterState: FilterState = {
+  tags: [],
+  priority: "all",
+  importance: "all",
+  kanbanStatus: "all",
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,21 +4,3 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
-
-// カラー設定を取得するヘルパー関数
-export function getColorConfig(color: string) {
-  const colorConfigs: Record<string, { color: string; bgClass: string; textClass: string; borderClass: string; activeClass: string }> = {
-    gray: { color: 'gray', bgClass: 'bg-gray-500', textClass: 'text-gray-600', borderClass: 'border-gray-300', activeClass: 'bg-gray-500 text-white' },
-    blue: { color: 'blue', bgClass: 'bg-blue-500', textClass: 'text-blue-600', borderClass: 'border-blue-300', activeClass: 'bg-blue-500 text-white' },
-    yellow: { color: 'yellow', bgClass: 'bg-yellow-500', textClass: 'text-yellow-600', borderClass: 'border-yellow-300', activeClass: 'bg-yellow-500 text-black' },
-    green: { color: 'green', bgClass: 'bg-green-500', textClass: 'text-green-600', borderClass: 'border-green-300', activeClass: 'bg-green-500 text-white' },
-    red: { color: 'red', bgClass: 'bg-red-500', textClass: 'text-red-600', borderClass: 'border-red-300', activeClass: 'bg-red-500 text-white' },
-    orange: { color: 'orange', bgClass: 'bg-orange-500', textClass: 'text-orange-600', borderClass: 'border-orange-300', activeClass: 'bg-orange-500 text-white' },
-    purple: { color: 'purple', bgClass: 'bg-purple-500', textClass: 'text-purple-600', borderClass: 'border-purple-300', activeClass: 'bg-purple-500 text-white' },
-    pink: { color: 'pink', bgClass: 'bg-pink-500', textClass: 'text-pink-600', borderClass: 'border-pink-300', activeClass: 'bg-pink-500 text-white' },
-    indigo: { color: 'indigo', bgClass: 'bg-indigo-500', textClass: 'text-indigo-600', borderClass: 'border-indigo-300', activeClass: 'bg-indigo-500 text-white' },
-    teal: { color: 'teal', bgClass: 'bg-teal-500', textClass: 'text-teal-600', borderClass: 'border-teal-300', activeClass: 'bg-teal-500 text-white' },
-  }
-
-  return colorConfigs[color] || colorConfigs.gray
-}

--- a/types/index.ts
+++ b/types/index.ts
@@ -110,95 +110,10 @@ export type KanbanStatusColumn = {
   updated_at?: string;
 };
 
-// カンバンカラム定義（デフォルト値 - DBから取得できない場合のフォールバック）
-export const DEFAULT_KANBAN_COLUMNS: KanbanStatusColumn[] = [
-  { id: "backlog", user_id: "", name: "backlog", label: "Backlog", color: "gray", bgClass: "bg-gray-500", textClass: "text-gray-600", borderClass: "border-gray-300", activeClass: "bg-gray-500 text-white", sortOrder: 0, isDefault: true },
-  { id: "todo", user_id: "", name: "todo", label: "Todo", color: "blue", bgClass: "bg-blue-500", textClass: "text-blue-600", borderClass: "border-blue-300", activeClass: "bg-blue-500 text-white", sortOrder: 1, isDefault: false },
-  { id: "doing", user_id: "", name: "doing", label: "Doing", color: "yellow", bgClass: "bg-yellow-500", textClass: "text-yellow-600", borderClass: "border-yellow-300", activeClass: "bg-yellow-500 text-black", sortOrder: 2, isDefault: false },
-  { id: "done", user_id: "", name: "done", label: "Done", color: "green", bgClass: "bg-green-500", textClass: "text-green-600", borderClass: "border-green-300", activeClass: "bg-green-500 text-white", sortOrder: 3, isDefault: false },
-];
-
-// 後方互換性のためのエイリアス
-export const KANBAN_COLUMNS = DEFAULT_KANBAN_COLUMNS;
-
-// 優先度設定の型
-type PriorityConfig = {
-  label: string;
-  color: string;
-  icon: string;
-  bgClass: string;
-  textClass: string;
-  badgeClass: string;
-  activeClass: string;
-};
-
-// 優先度の表示設定（完全なTailwindクラス名を使用）
-export const PRIORITY_CONFIG: Record<PriorityLevel, PriorityConfig> = {
-  high: { label: "高", color: "red", icon: "", bgClass: "bg-red-500", textClass: "text-red-600", badgeClass: "bg-red-100 text-red-700", activeClass: "bg-red-500 text-white" },
-  medium: { label: "中", color: "yellow", icon: "", bgClass: "bg-yellow-500", textClass: "text-yellow-600", badgeClass: "bg-yellow-100 text-yellow-700", activeClass: "bg-yellow-500 text-black" },
-  low: { label: "低", color: "blue", icon: "", bgClass: "bg-blue-500", textClass: "text-blue-600", badgeClass: "bg-blue-100 text-blue-700", activeClass: "bg-blue-500 text-white" },
-  none: { label: "-", color: "gray", icon: "", bgClass: "bg-gray-500", textClass: "text-gray-600", badgeClass: "bg-gray-100 text-gray-700", activeClass: "bg-gray-500 text-white" },
-};
-
-// 重要度設定の型
-type ImportanceConfig = {
-  label: string;
-  color: string;
-  icon: string;
-  bgClass: string;
-  textClass: string;
-  badgeClass: string;
-  activeClass: string;
-};
-
-// 重要度の表示設定（完全なTailwindクラス名を使用）
-export const IMPORTANCE_CONFIG: Record<ImportanceLevel, ImportanceConfig> = {
-  high: { label: "高", color: "red", icon: "", bgClass: "bg-red-500", textClass: "text-red-600", badgeClass: "bg-red-100 text-red-700", activeClass: "bg-red-500 text-white" },
-  medium: { label: "中", color: "yellow", icon: "", bgClass: "bg-yellow-500", textClass: "text-yellow-600", badgeClass: "bg-yellow-100 text-yellow-700", activeClass: "bg-yellow-500 text-black" },
-  low: { label: "低", color: "blue", icon: "", bgClass: "bg-blue-500", textClass: "text-blue-600", badgeClass: "bg-blue-100 text-blue-700", activeClass: "bg-blue-500 text-white" },
-  none: { label: "-", color: "gray", icon: "", bgClass: "bg-gray-500", textClass: "text-gray-600", badgeClass: "bg-gray-100 text-gray-700", activeClass: "bg-gray-500 text-white" },
-};
-
-// カンバンステータス用のカラー選択肢
-export const KANBAN_STATUS_COLORS = [
-  { name: "グレー", color: "gray", bgClass: "bg-gray-500", textClass: "text-gray-600", borderClass: "border-gray-300", activeClass: "bg-gray-500 text-white" },
-  { name: "ブルー", color: "blue", bgClass: "bg-blue-500", textClass: "text-blue-600", borderClass: "border-blue-300", activeClass: "bg-blue-500 text-white" },
-  { name: "イエロー", color: "yellow", bgClass: "bg-yellow-500", textClass: "text-yellow-600", borderClass: "border-yellow-300", activeClass: "bg-yellow-500 text-black" },
-  { name: "グリーン", color: "green", bgClass: "bg-green-500", textClass: "text-green-600", borderClass: "border-green-300", activeClass: "bg-green-500 text-white" },
-  { name: "レッド", color: "red", bgClass: "bg-red-500", textClass: "text-red-600", borderClass: "border-red-300", activeClass: "bg-red-500 text-white" },
-  { name: "オレンジ", color: "orange", bgClass: "bg-orange-500", textClass: "text-orange-600", borderClass: "border-orange-300", activeClass: "bg-orange-500 text-white" },
-  { name: "パープル", color: "purple", bgClass: "bg-purple-500", textClass: "text-purple-600", borderClass: "border-purple-300", activeClass: "bg-purple-500 text-white" },
-  { name: "ピンク", color: "pink", bgClass: "bg-pink-500", textClass: "text-pink-600", borderClass: "border-pink-300", activeClass: "bg-pink-500 text-white" },
-  { name: "インディゴ", color: "indigo", bgClass: "bg-indigo-500", textClass: "text-indigo-600", borderClass: "border-indigo-300", activeClass: "bg-indigo-500 text-white" },
-  { name: "ティール", color: "teal", bgClass: "bg-teal-500", textClass: "text-teal-600", borderClass: "border-teal-300", activeClass: "bg-teal-500 text-white" },
-];
-
-// デフォルトのタグカラー
-export const TAG_COLORS = [
-  { name: "レッド", value: "bg-red-500", textColor: "text-white" },
-  { name: "オレンジ", value: "bg-orange-500", textColor: "text-white" },
-  { name: "イエロー", value: "bg-yellow-500", textColor: "text-black" },
-  { name: "グリーン", value: "bg-green-500", textColor: "text-white" },
-  { name: "ブルー", value: "bg-blue-500", textColor: "text-white" },
-  { name: "インディゴ", value: "bg-indigo-500", textColor: "text-white" },
-  { name: "パープル", value: "bg-purple-500", textColor: "text-white" },
-  { name: "ピンク", value: "bg-pink-500", textColor: "text-white" },
-  { name: "グレー", value: "bg-gray-500", textColor: "text-white" },
-  { name: "ティール", value: "bg-teal-500", textColor: "text-white" },
-];
-
 // フィルター状態の型
 export type FilterState = {
   tags: string[]; // タグIDの配列
   priority: PriorityLevel | "all";
   importance: ImportanceLevel | "all";
   kanbanStatus: KanbanStatus | "all";
-};
-
-// 初期フィルター状態
-export const initialFilterState: FilterState = {
-  tags: [],
-  priority: "all",
-  importance: "all",
-  kanbanStatus: "all",
 };


### PR DESCRIPTION
## Summary

- **ST6-1** `getColorConfig` deleted from `lib/utils.ts` — zero callers, dead code. `PRIORITY_CONFIG` and `IMPORTANCE_CONFIG` now derive from single `LEVEL_CONFIG` source (values were identical — 8 duplicated lines eliminated)
- **ST6-2** All 7 value exports removed from `types/index.ts` (now types-only). Constants moved to `lib/constants.ts` alongside existing alarm/pomodoro constants. 10 importer files updated to import values from `@/lib/constants`

Import direction maintained: `lib/constants` → `@/types` (type imports only); no circular dependencies.

**Before:** `grep -n 'export const' types/index.ts` → 7 hits  
**After:** 0 hits

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 442/442 pass (3 skipped unchanged)
- [x] `grep -n 'export const' types/index.ts` — 0 results (completion condition met)
- [x] No behavior changes: pure import path mechanical update

🤖 Generated with [Claude Code](https://claude.com/claude-code)